### PR TITLE
Use diesel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,9 +4,11 @@ version = "0.1.0"
 authors = ["J/A <archer884@gmail.com>"]
 
 [dependencies]
+diesel = "0.9.0"
+diesel_codegen = { version = "0.9.0", features = ["postgres"] }
 dotenv = "*"
 iron = "*"
 postgres = "*"
 r2d2 = "*"
-r2d2_postgres = "*"
+r2d2-diesel = "*"
 serde = "*"

--- a/src/entity/fillup.rs
+++ b/src/entity/fillup.rs
@@ -1,8 +1,8 @@
-use postgres::rows::Row;
+use schema::fillup;
 
 /// Cost is stored as an integral value by first multiplying the 
 /// decimal value of the total fuel cost by 1000. 
-#[derive(Debug)]
+#[derive(Debug, Queryable)]
 pub struct Fillup {
     pub id: i64,
     pub user_id: i64,
@@ -11,39 +11,11 @@ pub struct Fillup {
     pub qty: f64,
 }
 
-pub trait CreateFillup {
-    fn user_id(&self) -> i64;
-    fn vehicle_id(&self) -> i64;
-    fn cost(&self) -> i64;
-    fn qty(&self) -> f64;
-}
-
-impl CreateFillup for (i64, i64, i64, f64) {
-    fn user_id(&self) -> i64 {
-        self.0
-    }
-
-    fn vehicle_id(&self) -> i64 {
-        self.1
-    }
-
-    fn cost(&self) -> i64 {
-        self.2
-    }
-
-    fn qty(&self) -> f64 {
-        self.3
-    }
-}
-
-impl<'a> From<Row<'a>> for Fillup {
-    fn from(row: Row) -> Self {
-        Fillup {
-            id: row.get(0),
-            user_id: row.get(1),
-            vehicle_id: row.get(2),
-            cost: row.get(3),
-            qty: row.get(4),
-        }
-    }
+#[derive(Insertable)]
+#[table_name="fillup"]
+pub struct NewFillup {
+    pub user_id: i64,
+    pub vehicle_id: i64,
+    pub cost: i64,
+    pub qty: f64,
 }

--- a/src/entity/mod.rs
+++ b/src/entity/mod.rs
@@ -2,6 +2,6 @@ mod fillup;
 mod user;
 mod vehicle;
 
-pub use entity::fillup::{Fillup, CreateFillup};
-pub use entity::user::{User, CreateUser};
-pub use entity::vehicle::{Vehicle, CreateVehicle};
+pub use entity::fillup::Fillup;
+pub use entity::user::User;
+pub use entity::vehicle::Vehicle;

--- a/src/entity/user.rs
+++ b/src/entity/user.rs
@@ -1,36 +1,15 @@
-use postgres::rows::Row;
+use schema::user;
 
-#[derive(Debug)]
+#[derive(Debug, Queryable)]
 pub struct User {
     pub id: i64,
     pub username: String,
     pub hash: String,
 }
 
-pub trait CreateUser {
-    fn username(&self) -> &str;
-    fn hash(&self) -> &str;
-}
-
-impl<'a, T1, T2> CreateUser for (T1, T2)
-    where T1: AsRef<str> + 'a,
-          T2: AsRef<str> + 'a,
-{
-    fn username(&self) -> &str {
-        self.0.as_ref()
-    }
-
-    fn hash(&self) -> &str {
-        self.1.as_ref()
-    }
-}
-
-impl<'a> From<Row<'a>> for User {
-    fn from(row: Row) -> Self {
-        User {
-            id: row.get(0),
-            username: row.get(1),
-            hash: row.get(2),
-        }
-    }
+#[derive(Insertable)]
+#[table_name="user"]
+pub struct NewUser<'a> {
+    pub username: &'a str,
+    pub hash: &'a str,
 }

--- a/src/entity/vehicle.rs
+++ b/src/entity/vehicle.rs
@@ -1,47 +1,18 @@
-use postgres::rows::Row;
+use schema::vehicle;
 
-#[derive(Debug)]
+#[derive(Debug, Queryable)]
 pub struct Vehicle {
     pub id: i64,
     pub user_id: i64,
     pub name: String,
-    pub desc: String,
+    pub description: Option<String>,
     pub image: Option<String>,
 }
 
-pub trait CreateVehicle {
-    fn user_id(&self) -> i64;
-    fn name(&self) -> &str;
-    fn desc(&self) -> &str;
-    fn image(&self) -> Option<&str>;
-}
-
-impl<'a, T: AsRef<str> + 'a> CreateVehicle for (i64, T, T) {
-    fn user_id(&self) -> i64 {
-        self.0
-    }
-    
-    fn name(&self) -> &str {
-        self.1.as_ref()
-    }
-
-    fn desc(&self) -> &str {
-        self.2.as_ref()
-    }
-
-    fn image(&self) -> Option<&str> {
-        None
-    }
-}
-
-impl<'a> From<Row<'a>> for Vehicle {
-    fn from(row: Row) -> Self {
-        Vehicle {
-            id: row.get(0),
-            user_id: row.get(1),
-            name: row.get(2),
-            desc: row.get(3),
-            image: row.get(4),
-        }
-    }
+#[derive(Insertable)]
+#[table_name="vehicle"]
+pub struct NewVehicle<'a> {
+    pub user_id: i64,
+    pub name: &'a str,
+    pub description: &'a str,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,19 @@
-#![feature(box_syntax)]
+#![feature(box_syntax, proc_macro)]
+
+#[macro_use] extern crate diesel;
+#[macro_use] extern crate diesel_codegen;
 
 extern crate dotenv;
 extern crate iron;
 extern crate postgres;
 extern crate r2d2;
-extern crate r2d2_postgres;
+extern crate r2d2_diesel;
 
-pub mod entity;
-pub mod service;
+// Must be public for `cargo doc`.
+pub mod schema;
+
+mod entity;
+mod service;
+
+pub use entity::*;
+pub use service::*;

--- a/src/schema/mod.rs
+++ b/src/schema/mod.rs
@@ -1,0 +1,1 @@
+infer_schema!("dotenv:DATABASE_URL");

--- a/src/service/page.rs
+++ b/src/service/page.rs
@@ -15,24 +15,24 @@ impl Page {
         }
     }
 
-    pub fn skip(&self) -> i64 {
+    pub fn offset(&self) -> i64 {
         self.index * self.size
     }
 
-    pub fn take(&self) -> i64 {
+    pub fn limit(&self) -> i64 {
         self.size
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::Page;
+    use service::Page;
     
     #[test]
     fn page_0_10() {
         let page = Page::new(0);
         
-        assert_eq!(0, page.skip());
-        assert_eq!(10, page.take());
+        assert_eq!(0, page.offset());
+        assert_eq!(10, page.limit());
     }
 }

--- a/src/service/user.rs
+++ b/src/service/user.rs
@@ -1,40 +1,22 @@
-use entity::{User, CreateUser};
+use diesel::prelude::*;
+use schema::user::dsl::*;
+use entity::User;
 use service::{IntoModel, ServiceConnection, ServiceResult};
 
-pub trait UserService {
-    fn create<T: CreateUser>(&self, user: T) -> ServiceResult<u64>;
-    fn by_id(&self, id: i64) -> ServiceResult<User>;
-    fn by_username(&self, username: &str) -> ServiceResult<User>;
-}
-
-pub struct PgUserService {
+pub struct UserService {
     connection: ServiceConnection
 }
 
-impl PgUserService {
-    pub fn new(connection: ServiceConnection) -> PgUserService {
-        PgUserService {
-            connection: connection
-        }
-    }
-}
-
-impl UserService for PgUserService {
-    fn create<T: CreateUser>(&self, user: T) -> ServiceResult<u64> {
-        let sql = include_str!("../../sql/user/create.sql");
-        Ok(self.connection.execute(sql, &[
-            &user.username(),
-            &user.hash(),
-        ])?)
+impl UserService {
+    pub fn new(connection: ServiceConnection) -> UserService {
+        UserService { connection: connection }
     }
     
-    fn by_id(&self, id: i64) -> ServiceResult<User> {
-        let sql = include_str!("../../sql/user/by_id.sql");
-        self.connection.query(sql, &[&id])?.single()
+    pub fn by_id(&self, target: i64) -> ServiceResult<User> {
+        user.filter(id.eq(target)).limit(1).load(&*self.connection).single()
     }
 
-    fn by_username(&self, username: &str) -> ServiceResult<User> {
-        let sql = include_str!("../../sql/user/by_username.sql");
-        self.connection.query(sql, &[&username])?.single()
+    pub fn by_username(&self, target: &str) -> ServiceResult<User> {
+        user.filter(username.eq(target)).limit(1).load(&*self.connection).single()
     }
 }

--- a/src/service/vehicle.rs
+++ b/src/service/vehicle.rs
@@ -1,42 +1,25 @@
-use entity::{Vehicle, CreateVehicle};
+use diesel::prelude::*;
+use entity::Vehicle;
+use schema::vehicle::dsl::*;
 use service::{IntoModel, Page, ServiceConnection, ServiceResult};
 
-pub trait VehicleService {
-    fn create<T: CreateVehicle>(&self, vehicle: T) -> ServiceResult<u64>;
-    fn by_id(&self, id: i64) -> ServiceResult<Vehicle>;
-    fn by_user(&self, id: i64, page: &Page) -> ServiceResult<Vec<Vehicle>>;
-}
-
-pub struct PgVehicleService {
+pub struct VehicleService {
     connection: ServiceConnection
 }
 
-impl PgVehicleService {
-    pub fn new(connection: ServiceConnection) -> PgVehicleService {
-        PgVehicleService {
-            connection: connection
-        }
+impl VehicleService {
+    pub fn new(connection: ServiceConnection) -> VehicleService {
+        VehicleService { connection: connection }
     }
-}
-
-impl VehicleService for PgVehicleService {
-    fn create<T: CreateVehicle>(&self, vehicle: T) -> ServiceResult<u64> {
-        let sql = include_str!("../../sql/vehicle/create.sql");
-        Ok(self.connection.execute(sql, &[
-            &vehicle.user_id(),
-            &vehicle.name(),
-            &vehicle.desc(),
-            &vehicle.image(),
-        ])?)
+    pub fn by_id(&self, target_id: i64) -> ServiceResult<Vehicle> {
+        vehicle.filter(id.eq(target_id)).limit(1).load(&*self.connection).single()
     }
 
-    fn by_id(&self, id: i64) -> ServiceResult<Vehicle> {
-        let sql = include_str!("../../sql/vehicle/by_id.sql");
-        self.connection.query(sql, &[&id])?.single()
-    }
-
-    fn by_user(&self, user_id: i64, page: &Page) -> ServiceResult<Vec<Vehicle>> {
-        let sql = include_str!("../../sql/vehicle/by_user.sql");
-        Ok(self.connection.query(sql, &[&user_id, &page.skip(), &page.take()])?.multiple())
+    pub fn by_user(&self, target_user_id: i64, page: &Page) -> ServiceResult<Vec<Vehicle>> {
+        vehicle.filter(user_id.eq(target_user_id))
+            .offset(page.offset())
+            .limit(page.limit())
+            .load(&*self.connection)
+            .multiple()
     }
 }


### PR DESCRIPTION
This patch converts the data layer to use Diesel rather than Postgres and hand-written queries, etc. It also does away with the indirection of the traits on which all service methods had previously been implemented.