### PR TITLE
Require only &self in service methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ diesel = "0.9.0"
 diesel_codegen = { version = "0.9.0", features = ["postgres"] }
 dotenv = "*"
 iron = "*"
+lazy_static = "*"
 postgres = "*"
 r2d2 = "*"
 r2d2-diesel = "*"

--- a/src/service/connection.rs
+++ b/src/service/connection.rs
@@ -23,19 +23,19 @@ impl ConnectionService {
         ConnectionService { pool: pool }
     }
 
-    pub fn users(&mut self) -> UserService {
+    pub fn users(&self) -> UserService {
         UserService::new(self.get_connection())
     }
 
-    pub fn vehicles(&mut self) -> VehicleService {
+    pub fn vehicles(&self) -> VehicleService {
         VehicleService::new(self.get_connection())
     }
 
-    pub fn fillups(&mut self) -> FillupService {
+    pub fn fillups(&self) -> FillupService {
         FillupService::new(self.get_connection())
     }
 
-    fn get_connection(&mut self) -> ServiceConnection {
+    fn get_connection(&self) -> ServiceConnection {
         self.pool.get().expect("unable to get connection")
     }
 }


### PR DESCRIPTION
r2d2 connection pooling is smart enough to create new connections without a mutable borrow of self, so there's no reason our method signatures should require it.